### PR TITLE
Installs all admin hosts as Shadow master

### DIFF
--- a/open-grid-scheduler/roles/ogs/tasks/head_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/head_postinstall.yml
@@ -22,3 +22,18 @@
   template:
     src: templates/shadow_masters.j2
     dest: /nfs/ogs/default/common/shadow_masters
+
+- name: Register if qmaster is running
+  stat: path=/nfs/ogs/default/spool/master/qmaster.pid
+  register: qmaster_pid
+  changed_when: False
+
+- name: Register if shadow daemon is running
+  stat: path=/nfs/ogs/default/spool/master/shadowd_{{ inventory_hostname }}.pid
+  register: shadowd_pid
+  changed_when: False
+
+- name: Start qmaster and or shadow daemon if pid does not exist
+  shell: /nfs/ogs/default/common/sgemaster
+  when: (qmaster_pid.stat.exists == False) or
+        (shadowd_pid.stat.exists == False)

--- a/open-grid-scheduler/roles/ogs/tasks/head_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/head_postinstall.yml
@@ -17,3 +17,8 @@
   environment:
     SGE_ROOT: /nfs/ogs
     SGE_ARCH: linux-x64
+
+- name: Create Shadow_masters template
+  template:
+    src: templates/shadow_masters.j2
+    dest: /nfs/ogs/default/common/shadow_masters

--- a/open-grid-scheduler/roles/ogs/tasks/workers_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/workers_postinstall.yml
@@ -17,3 +17,19 @@
   environment:
     SGE_ROOT: /nfs/ogs
     SGE_ARCH: linux-x64
+
+- name: Register if execd is running
+  stat: path=/nfs/ogs/default/spool/execd/{{ inventory_hostname }}/execd.pid
+  register: execd_pid
+  changed_when: False
+
+
+- name: Register if shadow daemon is running
+  stat: path=/nfs/ogs/default/spool/master/shadowd_{{ inventory_hostname }}.pid
+  register: shadowd_pid
+  changed_when: False
+
+- name: Start execd and or shadow daemon if pid does not exist
+  shell: /nfs/ogs/default/common/sgemaster
+  when:  (execd_pid.stat.exists == False) or
+         (shadowd_pid.stat.exists == False)

--- a/open-grid-scheduler/templates/shadow_masters.j2
+++ b/open-grid-scheduler/templates/shadow_masters.j2
@@ -1,0 +1,3 @@
+{% for host in ogs_admin_host_list %}
+{{ host }}
+{% endfor %}


### PR DESCRIPTION
All hosts defined as admin hosts will become a shadow master host.
First sets the shadow_master template and starts the shadow master daemon on the head node.
Then shadow master daemon will be started on the execution nodes.
If qmaster daemon  fails on the head node within 2 min the next shadow master will take over as qmaster node (will not work if you shut down nicely the qmaster daemon, only if the process is killed or a network error occurs).
If you want to migrate the qmaster daemon to another node, ssh into that node and execute this command `sudo /nfs/ogs/default/common/sgemaster -migrate`
