### PR TITLE
Add variables for extra submit hosts, extra users, and extra export folders.

### DIFF
--- a/open-grid-scheduler/Vagrantfile
+++ b/open-grid-scheduler/Vagrantfile
@@ -85,26 +85,26 @@ Vagrant.configure(VAGRANTFILE_API) do |config|
             "workers" => (1..N).map { |w| get_worker_name(w) }
           }
           # Extra variables for extra nfs_exports, extra users and extra submit hosts
-          ansible.extra_vars = {
-            nfs_extra_exports: [
-              {
-                path: "/exports",
-                options: "*(rw,sync,no_subtree_check,no_root_squash)"
-              }
-            ],
-            ogs_external_submit_hosts:[
-              {
-                hostname: "external_host",
-                ip_address: "10.0.0.10"
-              }
-            ],
-            ogs_extra_users:[
-              {
-                uid: "1300",
-                name: "extra"
-              }
-            ],
-          }
+          #ansible.extra_vars = {
+          #  nfs_extra_exports: [
+          #    {
+          #      path: "/exports",
+          #      options: "*(rw,sync,no_subtree_check,no_root_squash)"
+          #    }
+          #  ],
+          #  ogs_external_submit_hosts:[
+          #    {
+          #      hostname: "external_host",
+          #      ip_address: "10.0.0.10"
+          #    }
+          #  ],
+          #  ogs_extra_users:[
+          #    {
+          #      uid: "1300",
+          #      name: "extra"
+          #    }
+          #  ],
+          #}
         end
       end
     end

--- a/open-grid-scheduler/Vagrantfile
+++ b/open-grid-scheduler/Vagrantfile
@@ -84,6 +84,24 @@ Vagrant.configure(VAGRANTFILE_API) do |config|
             "head"    => [head_name],
             "workers" => (1..N).map { |w| get_worker_name(w) }
           }
+          # Extra variables for extra nfs_exports, extra users and extra submit hosts
+          ansible.extra_vars = {
+            nfs_extra_exports:
+              - {
+                path: "/exports",
+                options: "*(rw,sync,no_subtree_check,no_root_squash)"
+              },
+            ogs_external_submit_hosts:
+              - {
+                hostname: "external_host",
+                ip_address: 10.0.0.10
+              },
+            ogs_extra_users:
+              - {
+                uid: 1300,
+                name: "extra"
+              },
+          }
         end
       end
     end

--- a/open-grid-scheduler/Vagrantfile
+++ b/open-grid-scheduler/Vagrantfile
@@ -86,21 +86,24 @@ Vagrant.configure(VAGRANTFILE_API) do |config|
           }
           # Extra variables for extra nfs_exports, extra users and extra submit hosts
           ansible.extra_vars = {
-            nfs_extra_exports:
-              - {
+            nfs_extra_exports: [
+              {
                 path: "/exports",
                 options: "*(rw,sync,no_subtree_check,no_root_squash)"
-              },
-            ogs_external_submit_hosts:
-              - {
+              }
+            ],
+            ogs_external_submit_hosts:[
+              {
                 hostname: "external_host",
-                ip_address: 10.0.0.10
-              },
-            ogs_extra_users:
-              - {
-                uid: 1300,
+                ip_address: "10.0.0.10"
+              }
+            ],
+            ogs_extra_users:[
+              {
+                uid: "1300",
                 name: "extra"
-              },
+              }
+            ],
           }
         end
       end

--- a/open-grid-scheduler/Vagrantfile
+++ b/open-grid-scheduler/Vagrantfile
@@ -84,27 +84,8 @@ Vagrant.configure(VAGRANTFILE_API) do |config|
             "head"    => [head_name],
             "workers" => (1..N).map { |w| get_worker_name(w) }
           }
-          # Extra variables for extra nfs_exports, extra users and extra submit hosts
+          # Extra variables can be added by editing the extra_settings.yml file
           ansible.extra_vars = YAML.load_file('extra_settings.yml')
-          #  nfs_extra_exports: [
-          #    {
-          #      path: "/exports",
-          #      options: "*(rw,sync,no_subtree_check,no_root_squash)"
-          #    }
-          #  ],
-          #  ogs_external_submit_hosts:[
-          #    {
-          #      hostname: "external_host",
-          #      ip_address: "10.0.0.10"
-          #    }
-          #  ],
-          #  ogs_extra_users:[
-          #    {
-          #      uid: "1300",
-          #      name: "extra"
-          #    }
-          #  ],
-          #}
         end
       end
     end

--- a/open-grid-scheduler/Vagrantfile
+++ b/open-grid-scheduler/Vagrantfile
@@ -85,7 +85,7 @@ Vagrant.configure(VAGRANTFILE_API) do |config|
             "workers" => (1..N).map { |w| get_worker_name(w) }
           }
           # Extra variables for extra nfs_exports, extra users and extra submit hosts
-          #ansible.extra_vars = {
+          ansible.extra_vars = YAML.load_file('extra_settings.yml')
           #  nfs_extra_exports: [
           #    {
           #      path: "/exports",

--- a/open-grid-scheduler/extra_settings.yml
+++ b/open-grid-scheduler/extra_settings.yml
@@ -1,0 +1,15 @@
+# Extra vatiables for starting up the OGS cluster.
+
+#nfs_extra_exports:  # A list of dictionaries that sets the path for extra shared folders on the cluster
+#  - path: "/exports"
+#    options: "*(rw,sync,no_subtree_check,no_root_squash)" #options for nfs
+
+#ogs_external_submit_hosts: # A list of dictionaries that sets external submit hosts
+#  - hostname: "external_host"
+#    ip_address: "10.0.0.10"
+#  - hostname: "another_external_host"
+#    ip_address: "10.0.0.20"
+
+#ogs_extra_users: # A list of dictionaries that sets users on the cluster with a certain uid.
+#  - uid: "1300"
+#    name: "extra"

--- a/open-grid-scheduler/roles/ogs/defaults/main.yml
+++ b/open-grid-scheduler/roles/ogs/defaults/main.yml
@@ -8,20 +8,11 @@ ogs_admin_private_key: files/ogs-admin_rsa
 ogs_admin_public_key: files/ogs-admin_rsa.pub
 ogs_version: GE2011.11p1
 nfs_exports:
-  - "/nfs/ogs *(rw,sync,no_subtree_check,no_root_squash)"
-  - "/nfs/sandbox *(rw,sync,no_subtree_check,no_root_squash)"
-nfs_exports:
   - path: "/nfs/ogs"
     options: "*(rw,sync,no_subtree_check,no_root_squash)"
   - path: "/nfs/sandbox"
     options: "*(rw,sync,no_subtree_check,no_root_squash)"
 nfs_extra_exports: []
-#ogs_external_submit_hosts:
-#  - hostname: "external_host"
-#    ip_address: 10.0.0.10
-#ogs_extra_users:
-#  - uid: 1300
-#    name: "extra"
 ogs_sge_root: /nfs/ogs
 ogs_sge_qmaster_port: 6444
 ogs_sge_execd_port: 6445

--- a/open-grid-scheduler/roles/ogs/defaults/main.yml
+++ b/open-grid-scheduler/roles/ogs/defaults/main.yml
@@ -10,7 +10,16 @@ ogs_version: GE2011.11p1
 nfs_exports:
   - "/nfs/ogs *(rw,sync,no_subtree_check,no_root_squash)"
   - "/nfs/sandbox *(rw,sync,no_subtree_check,no_root_squash)"
-
+nfs_exports:
+  - path: "/nfs/ogs"
+    options: "*(rw,sync,no_subtree_check,no_root_squash)"
+  - path: "/nfs/sandbox"
+    options: "*(rw,sync,no_subtree_check,no_root_squash)"
+nfs_extra_exports: []
+ogs_external_submit_hosts: []
+#  - hostname: "external_host"
+#    ip_address: 10.0.0.10
+#
 ogs_sge_root: /nfs/ogs
 ogs_sge_qmaster_port: 6444
 ogs_sge_execd_port: 6445

--- a/open-grid-scheduler/roles/ogs/defaults/main.yml
+++ b/open-grid-scheduler/roles/ogs/defaults/main.yml
@@ -16,10 +16,12 @@ nfs_exports:
   - path: "/nfs/sandbox"
     options: "*(rw,sync,no_subtree_check,no_root_squash)"
 nfs_extra_exports: []
-ogs_external_submit_hosts: []
+#ogs_external_submit_hosts:
 #  - hostname: "external_host"
 #    ip_address: 10.0.0.10
-#
+#ogs_extra_users:
+#  - uid: 1300
+#    name: "extra"
 ogs_sge_root: /nfs/ogs
 ogs_sge_qmaster_port: 6444
 ogs_sge_execd_port: 6445

--- a/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
@@ -2,9 +2,7 @@
 
 # TODO: parse this from `nfs_exports` directly
 - name: ensure all items in shared mounts are correctly owned
-  command: find {{ item }} -exec chown {{ ogs_admin_user }}:{{ ogs_group }} {} \;
+  command: find {{ item.path }} -exec chown {{ ogs_admin_user }}:{{ ogs_group }} {} \;
   register: chmod_result
   changed_when: "chmod_result.stdout != \"\""
-  with_items:
-    - /nfs/ogs
-    - /nfs/sandbox
+  with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"

--- a/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
@@ -5,28 +5,28 @@
   command: find {{ item.path }} -exec chown {{ ogs_admin_user }}:{{ ogs_group }} {} \;
   register: chmod_result
   changed_when: "chmod_result.stdout != \"\""
-  with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"
+  with_items: "{{ nfs_exports }} + {{ nfs_extra_exports }}"
 
 - name: Create extra users for job submission
   user:
-    uid: "{{item.uid}}"
-    name: "{{item.name}}"
+    uid: "{{ item.uid }}"
+    name: "{{ item.name }}"
     state: present
-  with_items: "{{ogs_extra_users}}"
+  with_items: "{{ ogs_extra_users }}"
   when: ogs_extra_users is defined
 
 - name: Add external submit hosts to /etc/hosts
   lineinfile:
-    line: "{{item.ip_address}} {{item.hostname}}"
+    line: "{{ item.ip_address }} {{ item.hostname}}"
     name: "/etc/hosts"
-  with_items: "{{ogs_external_submit_hosts}}"
+  with_items: "{{ ogs_external_submit_hosts }}"
   when: ogs_external_submit_hosts is defined
 
 - name: Add external submit hosts
-  command: "{{ogs_sge_root}}/bin/linux-x64/qconf -as {{item.hostname}}"
+  command: "{{ ogs_sge_root }}/bin/linux-x64/qconf -as {{ item.hostname }}"
   become: yes
   become_user: ogs-admin
   environment:
-    SGE_ROOT: "{{ogs_sge_root}}"
-  with_items: "{{ogs_external_submit_hosts}}"
+    SGE_ROOT: "{{ ogs_sge_root }}"
+  with_items: "{{ ogs_external_submit_hosts }}"
   when: ogs_external_submit_hosts is defined

--- a/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
@@ -7,7 +7,7 @@
   changed_when: "chmod_result.stdout != \"\""
   with_items: "{{ nfs_exports }} + {{ nfs_extra_exports }}"
 
-- name: Create extra users for job submission
+- name: create extra users for job submission
   user:
     uid: "{{ item.uid }}"
     name: "{{ item.name }}"
@@ -15,14 +15,14 @@
   with_items: "{{ ogs_extra_users }}"
   when: ogs_extra_users is defined
 
-- name: Add external submit hosts to /etc/hosts
+- name: add external submit hosts to /etc/hosts
   lineinfile:
     line: "{{ item.ip_address }} {{ item.hostname}}"
     name: "/etc/hosts"
   with_items: "{{ ogs_external_submit_hosts }}"
   when: ogs_external_submit_hosts is defined
 
-- name: Add external submit hosts
+- name: add external submit hosts
   command: "{{ ogs_sge_root }}/bin/linux-x64/qconf -as {{ item.hostname }}"
   become: yes
   become_user: ogs-admin

--- a/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/common_postinstall.yml
@@ -6,3 +6,27 @@
   register: chmod_result
   changed_when: "chmod_result.stdout != \"\""
   with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"
+
+- name: Create extra users for job submission
+  user:
+    uid: "{{item.uid}}"
+    name: "{{item.name}}"
+    state: present
+  with_items: "{{ogs_extra_users}}"
+  when: ogs_extra_users is defined
+
+- name: Add external submit hosts to /etc/hosts
+  lineinfile:
+    line: "{{item.ip_address}} {{item.hostname}}"
+    name: "/etc/hosts"
+  with_items: "{{ogs_external_submit_hosts}}"
+  when: ogs_external_submit_hosts is defined
+
+- name: Add external submit hosts
+  command: "{{ogs_sge_root}}/bin/linux-x64/qconf -as {{item.hostname}}"
+  become: yes
+  become_user: ogs-admin
+  environment:
+    SGE_ROOT: "{{ogs_sge_root}}"
+  with_items: "{{ogs_external_submit_hosts}}"
+  when: ogs_external_submit_hosts is defined

--- a/open-grid-scheduler/roles/ogs/tasks/workers.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/workers.yml
@@ -15,7 +15,7 @@
     owner: "{{ ogs_admin_user }}"
     group: "{{ ogs_group }}"
     mode: 0755
-  with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"
+  with_items: "{{ nfs_exports }} + {{ nfs_extra_exports }}"
 
 
 - name: mount nfs
@@ -24,4 +24,4 @@
     fstype: nfs
     src: "{{ hostvars[groups['head'][0]].ansible_eth1.ipv4.address }}:{{ item.path }}"
     state: mounted
-  with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"
+  with_items: "{{ nfs_exports }} + {{ nfs_extra_exports }}"

--- a/open-grid-scheduler/roles/ogs/tasks/workers.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/workers.yml
@@ -22,6 +22,6 @@
   mount:
     name: "{{ item.path }}"
     fstype: nfs
-    src: "{{ hostvars[groups['head'][0]].ansible_eth1.ipv4.address }}:{{ item }}"
+    src: "{{ hostvars[groups['head'][0]].ansible_eth1.ipv4.address }}:{{ item.path }}"
     state: mounted
   with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"

--- a/open-grid-scheduler/roles/ogs/tasks/workers.yml
+++ b/open-grid-scheduler/roles/ogs/tasks/workers.yml
@@ -9,13 +9,19 @@
   authorized_key: user={{ ogs_admin_user }} key="{{ lookup('file', ogs_admin_public_key) }}"
 
 - name: ensure mount point for nfs exists
-  file: path={{ item }} state=directory owner={{ ogs_admin_user }} group={{ ogs_group }} mode=0755
-  with_items:
-    - /nfs/ogs
-    - /nfs/sandbox
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ ogs_admin_user }}"
+    group: "{{ ogs_group }}"
+    mode: 0755
+  with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"
+
 
 - name: mount nfs
-  mount: name={{ item }} fstype=nfs src="{{ hostvars[groups['head'][0]].ansible_eth1.ipv4.address }}:{{ item }}" state=mounted
-  with_items:
-    - /nfs/ogs
-    - /nfs/sandbox
+  mount:
+    name: "{{ item.path }}"
+    fstype: nfs
+    src: "{{ hostvars[groups['head'][0]].ansible_eth1.ipv4.address }}:{{ item }}"
+    state: mounted
+  with_items: "{{nfs_exports}} + {{nfs_extra_exports}}"

--- a/role-nfs/tasks/main.yml
+++ b/role-nfs/tasks/main.yml
@@ -7,8 +7,9 @@
     - nfs-kernel-server
 
 - name: ensure export directories exist
-  file: path="{{ item.path }}"
-  state: directory
+  file:
+    path: "{{ item.path }}"
+    state: directory
   with_items: "{{ nfs_exports }}"
   notify: restart nfs
 

--- a/role-nfs/tasks/main.yml
+++ b/role-nfs/tasks/main.yml
@@ -10,7 +10,7 @@
   file:
     path: "{{ item.path }}"
     state: directory
-  with_items: "{{ nfs_exports }} + {{nfs_extra_exports}}"
+  with_items: "{{ nfs_exports }} + {{ nfs_extra_exports }}"
   notify: restart nfs
 
 - name: copy exports file

--- a/role-nfs/tasks/main.yml
+++ b/role-nfs/tasks/main.yml
@@ -10,7 +10,7 @@
   file:
     path: "{{ item.path }}"
     state: directory
-  with_items: "{{ nfs_exports }}"
+  with_items: "{{ nfs_exports }} + {{nfs_extra_exports}}"
   notify: restart nfs
 
 - name: copy exports file

--- a/role-nfs/tasks/main.yml
+++ b/role-nfs/tasks/main.yml
@@ -7,7 +7,8 @@
     - nfs-kernel-server
 
 - name: ensure export directories exist
-  file: path="{{ item.strip().split()[0] }}" state=directory
+  file: path="{{ item.path }}"
+  state: directory
   with_items: "{{ nfs_exports }}"
   notify: restart nfs
 

--- a/role-nfs/templates/exports.j2
+++ b/role-nfs/templates/exports.j2
@@ -11,10 +11,10 @@
 # /srv/nfs4/homes  gss/krb5i(rw,sync,no_subtree_check)
 #
 {% for export in nfs_exports %}
-{{ export.path }} {{export.options}}
+{{ export.path }} {{ export.options }}
 {% endfor %}
 {% if nfs_extra_exports is defined %}
 {% for export in nfs_extra_exports %}
-{{ export.path }} {{export.options}}
+{{ export.path }} {{ export.options }}
 {% endfor %}
 {% endif %}

--- a/role-nfs/templates/exports.j2
+++ b/role-nfs/templates/exports.j2
@@ -13,3 +13,8 @@
 {% for export in nfs_exports %}
 {{ export.path }} {{export.options}}
 {% endfor %}
+{% if nfs_extra_exports is defined %}
+{% for export in nfs_extra_exports %}
+{{ export.path }} {{export.options}}
+{% endfor %}
+{% endif %}

--- a/role-nfs/templates/exports.j2
+++ b/role-nfs/templates/exports.j2
@@ -11,5 +11,5 @@
 # /srv/nfs4/homes  gss/krb5i(rw,sync,no_subtree_check)
 #
 {% for export in nfs_exports %}
-{{ export }}
+{{ export.path }} {{export.options}}
 {% endfor %}


### PR DESCRIPTION
Very useful if say, you have an other vagrant box set up that you want to test for submitting jobs on an ogs_cluster. For example a galaxy box.
The setup has been tested with and without extra variables and in both cases worked.
